### PR TITLE
Add const to Message param in writeToNode

### DIFF
--- a/sdk/streaming-worker.h
+++ b/sdk/streaming-worker.h
@@ -99,7 +99,7 @@ class StreamingWorker : public AsyncProgressWorker {
 
  protected:
 
-  void writeToNode(const AsyncProgressWorker::ExecutionProgress& progress, Message & msg){
+  void writeToNode(const AsyncProgressWorker::ExecutionProgress& progress, const Message & msg){
     toNode.write(msg);
     progress.Send(reinterpret_cast<const char*>(&toNode), sizeof(toNode));
   }


### PR DESCRIPTION
If you add Add const to Message param in writeToNode we could use the method with temporary Message object.
