### PR TITLE
sdk/streaming-worker.h: delete progress & error callbacks in destructor

### DIFF
--- a/sdk/streaming-worker.h
+++ b/sdk/streaming-worker.h
@@ -73,7 +73,11 @@ class StreamingWorker : public AsyncProgressWorker {
     {
       input_closed = false;
     }
-  ~StreamingWorker() {}
+
+  ~StreamingWorker() {
+    delete progress;
+    delete error_callback;
+  }
 
   void HandleErrorCallback() {
     HandleScope scope;


### PR DESCRIPTION
Nobody deletes the progress & error callbacks passed into the StreamingWorker class.

The addon function allocates three `Nan::Callback` objects, called
`progress`, `error_callback` and `callback`.

`callback` is passed into the `StreamingWorker` constructor, where it
is then passed into the `AsyncProgressWorker` constructor, where it is
then passed into the `AsyncWorker` constructor. It gets deleted
by the `AsyncWorker` destructor after work is complete.

`error_callback` is passed into the `StreamingWorker` constructor.  It is called
in `HandleErrorCallback` but it never gets deleted.

`progress` is passed into the `StreamingWorker` constructor.  It is called
in `drainQueue` but it never gets deleted.

Earlier today, we identified this same issue in the Nan unit tests:
https://github.com/nodejs/nan/issues/698

...and a similar fix has been applied and merged:
https://github.com/nodejs/nan/pull/699

closes #7 